### PR TITLE
Use chisel models for iron bars blockstate

### DIFF
--- a/src/main/resources/assets/cathedral/blockstates/dwemer_bars_normal.json
+++ b/src/main/resources/assets/cathedral/blockstates/dwemer_bars_normal.json
@@ -1,57 +1,63 @@
 {
   "forge_marker": 1,
   "defaults": {
-    "model": "iron_bars_post_ends"
+    "model": "chisel:bars_post_ends"
   },
   "variants": {
-  
+
      "variant": {
 		"normal": { "textures": { 	"bars": 	"cathedral:blocks/dwemer/bars_normal_normal",
 									"edge": 	"cathedral:blocks/dwemer/bars_normal_empty",
+									"side": 	"cathedral:blocks/dwemer/bars_normal_empty",
 									"particle": "cathedral:blocks/dwemer/bars_normal_side" } },
 		"ornate": { "textures": { 	"bars": 	"cathedral:blocks/dwemer/bars_normal_ornate",
 									"edge": 	"cathedral:blocks/dwemer/bars_normal_empty",
+									"side": 	"cathedral:blocks/dwemer/bars_normal_empty",
 									"particle": "cathedral:blocks/dwemer/bars_normal_ornate" } },
 		"footer": { "textures": { 	"bars": 	"cathedral:blocks/dwemer/bars_normal_footer",
 									"edge":		"cathedral:blocks/dwemer/bars_normal_empty",
+									"side":		"cathedral:blocks/dwemer/bars_normal_empty",
 									"particle":	"cathedral:blocks/dwemer/bars_normal_footer" } },
 		"header": { "textures": { 	"bars": 	"cathedral:blocks/dwemer/bars_normal_header",
 									"edge": 	"cathedral:blocks/dwemer/bars_normal_empty",
+									"side": 	"cathedral:blocks/dwemer/bars_normal_empty",
 									"particle": "cathedral:blocks/dwemer/bars_normal_header" } },
 		"mask": { "textures": { 	"bars": 	"cathedral:blocks/dwemer/bars_normal_mask",
 									"edge": 	"cathedral:blocks/dwemer/bars_normal_empty",
+									"side": 	"cathedral:blocks/dwemer/bars_normal_empty",
 									"particle": "cathedral:blocks/dwemer/bars_normal_mask" } },
 		"rhombus": { "textures": { 	"bars": 	"cathedral:blocks/dwemer/bars_normal_rhombus",
 									"edge": 	"cathedral:blocks/dwemer/bars_normal_empty",
+									"side": 	"cathedral:blocks/dwemer/bars_normal_empty",
 									"particle": "cathedral:blocks/dwemer/bars_normal_rhombus" } }
 	},
-    
+
     "capping": {
     	"none": {},
-		"post": { "submodel": "iron_bars_post" },
-		"north": { "submodel": "iron_bars_cap" },
-		"east": { "submodel": "iron_bars_cap", "y": 90 },
-		"south": { "submodel": "iron_bars_cap_alt" },
-		"west": { "submodel": "iron_bars_cap_alt", "y": 90 }
+		"post": { "submodel": "chisel:bars_post" },
+		"north": { "submodel": "chisel:bars_cap" },
+		"east": { "submodel": "chisel:bars_cap", "y": 90 },
+		"south": { "submodel": "chisel:bars_cap_alt" },
+		"west": { "submodel": "chisel:bars_cap_alt", "y": 90 }
     },
-    
+
 	"north": {
-		"true": { "submodel": "iron_bars_side" },
+		"true": { "submodel": "chisel:bars_side" },
 		"false" : {}
-	}, 
+	},
 
 	"east": {
-		"true": { "submodel": "iron_bars_side", "y": 90 },
+		"true": { "submodel": "chisel:bars_side", "y": 90 },
 		"false" : {}
-	}, 
+	},
 
 	"south": {
-		"true": { "submodel": "iron_bars_side_alt" },
+		"true": { "submodel": "chisel:bars_side_alt" },
 		"false" : {}
-	},  
+	},
 
 	"west": {
-		"true": { "submodel": "iron_bars_side_alt", "y": 90 },
+		"true": { "submodel": "chisel:bars_side_alt", "y": 90 },
 		"false" : {}
 	}
 }


### PR DESCRIPTION
Addresses https://github.com/ferreusveritas/Cathedral/issues/15 by preventing resource packs that overwrite the iron bars model from affecting the dwemer bars.